### PR TITLE
Don't catch detect screen= in the middle of words

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
           logCommand(command);
         }
 
-        if (command.indexOf('screen=') === -1 && defaultScreen) {
+        if (command.indexOf(' screen=') === -1 && defaultScreen) {
           command += ' screen=' + defaultScreen;
         }
 


### PR DESCRIPTION
A url like `https://example.com?fullscreen=1` get's caught by this code, and it is very confusing.
